### PR TITLE
feat: listar cursos con servicio localStorage

### DIFF
--- a/src/componentes/CourseCard.jsx
+++ b/src/componentes/CourseCard.jsx
@@ -1,0 +1,9 @@
+// src/componentes/CourseCard.jsx
+export default function CourseCard({ course }) {
+  return (
+    <article className="card">
+      <h3>{course.titulo}</h3>
+      <p>{course.descripcion || "Sin descripción"}</p>
+    </article>
+  );
+}

--- a/src/paginas/Courses.jsx
+++ b/src/paginas/Courses.jsx
@@ -1,0 +1,22 @@
+// src/paginas/Courses.jsx
+import { useEffect, useState } from "react";
+import { listarCursos } from "../servicios/courseService";
+import CourseCard from "../componentes/CourseCard";
+
+export default function Courses() {
+  const [cursos, setCursos] = useState([]);
+
+  useEffect(() => {
+    listarCursos().then(setCursos);
+  }, []);
+
+  return (
+    <section>
+      <h2>Gestión de Cursos</h2>
+      <div className="grid">
+        {cursos.length === 0 && <p>No hay cursos aún.</p>}
+        {cursos.map(c => <CourseCard key={c.id} course={c} />)}
+      </div>
+    </section>
+  );
+}

--- a/src/servicios/courseService.js
+++ b/src/servicios/courseService.js
@@ -1,0 +1,11 @@
+// src/servicios/courseService.js
+const STORAGE_KEY = "curso_online_cursos";
+
+function readAll() {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  return raw ? JSON.parse(raw) : [];
+}
+
+export async function listarCursos() {
+  return readAll();
+}


### PR DESCRIPTION
Se implementa la funcionalidad de lectura de cursos desde localStorage y su renderizado en la página de cursos.

Cambios realizados:
- src/servicios/courseService.js: añade función listarCursos() para obtener los cursos almacenados.
- src/componentes/CourseCard.jsx: componente de presentación para cada curso.
- src/paginas/Courses.jsx: consume listarCursos() y muestra los cursos en un grid.
- src/App.jsx y src/main.jsx: rutas mínimas para navegación.

Closes #4 